### PR TITLE
Fixed TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,9 @@
 
 /// <reference types="node" />
 
+import * as net from "net";
 
-export type NodeJSSocketWithFileDescriptor = NodeJS.Socket | { _handle: { _fd: number } }
+export type NodeJSSocketWithFileDescriptor = net.Socket | { _handle: { _fd: number } }
 
 export function setKeepAliveInterval(socket: NodeJSSocketWithFileDescriptor, intvl: number): number
 


### PR DESCRIPTION
The current typings cause a compile-time error for my whole project:

    /vagrant/server/node_modules/net-keepalive/index.d.ts(9,53): error TS2694: Namespace 'NodeJS' has no exported member 'Socket'.
    /vagrant/server/node_modules/net-keepalive/index.d.ts(9,53): error TS2694: Namespace 'NodeJS' has no exported member 'Socket'.

This is with TypeScript 2.7.2 Making the above changes fixes it for me.