### PR TITLE
feat: TCP_USER_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Missing (`TCP_KEEPINTVL` and `TCP_KEEPCNT`) `SO_KEEPALIVE` socket option set
 
 Tested on 🐧 `linux` & 🍏 `osx` (both `amd64` and `arm64`), should work on 😈 `freebsd` and others. Does not work on 🐄 `win32` (pull requests welcome).
 
-There's also linux support for setting the `TCP_USER_TIMEOUT` option, which is closely related to keep-alive.
+There's also linux support for getting & setting the `TCP_USER_TIMEOUT` (linux 🐧 only) option, which is closely related to keep-alive.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The Missing (`TCP_KEEPINTVL` and `TCP_KEEPCNT`) `SO_KEEPALIVE` socket option set
 
 Tested on 🐧 `linux` & 🍏 `osx` (both `amd64` and `arm64`), should work on 😈 `freebsd` and others. Does not work on 🐄 `win32` (pull requests welcome).
 
+There's also linux support for setting the `TCP_USER_TIMEOUT` option, which is closely related to keep-alive.
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Missing (`TCP_KEEPINTVL` and `TCP_KEEPCNT`) `SO_KEEPALIVE` socket option set
 
 Tested on 🐧 `linux` & 🍏 `osx` (both `amd64` and `arm64`), should work on 😈 `freebsd` and others. Does not work on 🐄 `win32` (pull requests welcome).
 
-There's also linux support for getting & setting the `TCP_USER_TIMEOUT` (linux 🐧 only) option, which is closely related to keep-alive.
+There's also support for getting & setting the `TCP_USER_TIMEOUT` (linux 🐧 only) option, which is closely related to keep-alive.
 
 ## Install
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,3 +28,12 @@ export function setKeepAliveProbes(
 export function getKeepAliveProbes(
   socket: NodeJSSocketWithFileDescriptor
 ): number
+
+export function setUserTimeout(
+  socket: NodeJSSocketWithFileDescriptor,
+  timeout: number
+): boolean
+
+export function getUserTimeout(
+  socket: NodeJSSocketWithFileDescriptor
+): number

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,8 +5,10 @@ import { expectType } from 'tsd'
 Net.createServer((incomingSocket) => {
   expectType<boolean>(NetKeepAlive.setKeepAliveInterval(incomingSocket, 1000))
   expectType<boolean>(NetKeepAlive.setKeepAliveProbes(incomingSocket, 1))
+  expectType<boolean>(NetKeepAlive.setUserTimeout(incomingSocket, 5000))
 })
 
 const clientSocket = Net.createConnection({port: -1})
 expectType<boolean>(NetKeepAlive.setKeepAliveInterval(clientSocket, 1000))
 expectType<boolean>(NetKeepAlive.setKeepAliveProbes(clientSocket, 1))
+expectType<boolean>(NetKeepAlive.setUserTimeout(clientSocket, 5000))

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,6 +6,7 @@ const Constants = {
   SOL_TCP: 6,
   TCP_KEEPINTVL: undefined,
   TCP_KEEPCNT: undefined,
+  TCP_USER_TIMEOUT: undefined,
 }
 
 switch (OS.platform()) {
@@ -23,6 +24,7 @@ switch (OS.platform()) {
   default:
     Constants.TCP_KEEPINTVL = 5
     Constants.TCP_KEEPCNT = 6
+    Constants.TCP_USER_TIMEOUT = 18
     break
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,9 @@ module.exports.getKeepAliveProbes = function getKeepAliveProbes(socket) {
  * Notes:
  * * This method is only supported on `linux`, will throw on `darwin` and `freebsd`.
  * * The msec will be rounded towards the closest integer.
+ * * When used with the TCP keepalive options, will override them.
  *
+ * @see {@link https://man7.org/linux/man-pages/man7/tcp.7.html|tcp(7):TCP_USER_TIMEOUT }
  *
  * @since v1.4.0
  * @param {Net.Socket} socket to set the value for

--- a/lib/index.js
+++ b/lib/index.js
@@ -225,7 +225,7 @@ module.exports.getKeepAliveProbes = function getKeepAliveProbes(socket) {
  *
  * @returns {boolean} <code>true</code> on success
  *
- * @example <caption>Set user timeout to 30 seconds (<code>1000</code> milliseconds) for socket <code>s</code></caption>
+ * @example <caption>Set user timeout to 30 seconds (<code>30000</code> milliseconds) for socket <code>s</code></caption>
  * NetKeepAlive.setUserTimeout(s, 30000)
  *
  * @throws {AssertionError} setUserTimeout requires two arguments

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,3 +213,96 @@ module.exports.getKeepAliveProbes = function getKeepAliveProbes(socket) {
 
   return cntVal.deref()
 }
+
+/**
+ * Sets the TCP_USER_TIMEOUT value for specified socket.
+ *
+ * Note: The msec will be rounded towards the closest integer
+ *
+ * @since v1.4.0
+ * @param {Net.Socket} socket to set the value for
+ * @param {number} msecs to wait for unacknowledged data before closing the connection
+ *
+ * @returns {boolean} <code>true</code> on success
+ *
+ * @example <caption>Set user timeout to 30 seconds (<code>1000</code> milliseconds) for socket <code>s</code></caption>
+ * NetKeepAlive.setUserTimeout(s, 30000)
+ *
+ * @throws {AssertionError} setUserTimeout requires two arguments
+ * @throws {AssertionError} setUserTimeout expects an instance of socket as its first argument
+ * @throws {AssertionError} setUserTimeout requires msec to be a Number
+ * @throws {ErrnoException|Error} Unexpected error
+ */
+module.exports.setUserTimeout = function setUserTimeout(
+  socket,
+  msecs
+) {
+  Assert.strictEqual(
+    arguments.length,
+    2,
+    'setUserTimeout requires two arguments'
+  )
+  Assert(
+    _isSocket(socket),
+    'setUserTimeout expects an instance of socket as its first argument'
+  )
+  Assert.strictEqual(
+    msecs != null ? msecs.constructor : void 0,
+    Number,
+    'setUserTimeout requires msec to be a Number'
+  )
+
+  const fd = _getSocketFD(socket),
+    seconds = ~~msecs,
+    intvlVal = Ref.alloc('int', seconds),
+    intvlValLn = intvlVal.type.size
+
+  return FFIBindings.setsockopt(
+    fd,
+    Constants.SOL_TCP,
+    Constants.TCP_USER_TIMEOUT,
+    intvlVal,
+    intvlValLn
+  )
+}
+
+/**
+ * Returns the TCP_USER_TIMEOUT value for specified socket.
+ *
+ * @since v1.4.0
+ * @param {Net.Socket} socket to check the value for
+ *
+ * @returns {number} msecs to wait for unacknowledged data before closing the connection
+ *
+ * @example <caption>Get the current user timeout for socket <code>s</code></caption>
+ * NetKeepAlive.getUserTimeout(s) // returns 30000 based on setter example
+ *
+ * @throws {AssertionError} getUserTimeout requires one arguments
+ * @throws {AssertionError} getUserTimeout expects an instance of socket as its first argument
+ * @throws {ErrnoException|Error} Unexpected error
+ */
+module.exports.getUserTimeout = function getUserTimeout(socket) {
+  Assert.strictEqual(
+    arguments.length,
+    1,
+    'getUserTimeout requires one arguments'
+  )
+  Assert(
+    _isSocket(socket),
+    'getUserTimeout expects an instance of socket as its first argument'
+  )
+
+  const fd = _getSocketFD(socket),
+    intvlVal = Ref.alloc(Ref.types.uint32),
+    intvlValLn = Ref.alloc(Ref.types.uint32, intvlVal.type.size)
+
+  FFIBindings.getsockopt(
+    fd,
+    Constants.SOL_TCP,
+    Constants.TCP_USER_TIMEOUT,
+    intvlVal,
+    intvlValLn
+  )
+
+  return intvlVal.deref()
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -253,16 +253,16 @@ module.exports.setUserTimeout = function setUserTimeout(
   )
 
   const fd = _getSocketFD(socket),
-    seconds = ~~msecs,
-    intvlVal = Ref.alloc('int', seconds),
-    intvlValLn = intvlVal.type.size
+    msecInt = ~~msecs,
+    msecVal = Ref.alloc('int', msecInt),
+    msecValLn = msecVal.type.size
 
   return FFIBindings.setsockopt(
     fd,
     Constants.SOL_TCP,
     Constants.TCP_USER_TIMEOUT,
-    intvlVal,
-    intvlValLn
+    msecVal,
+    msecValLn
   )
 }
 
@@ -293,16 +293,16 @@ module.exports.getUserTimeout = function getUserTimeout(socket) {
   )
 
   const fd = _getSocketFD(socket),
-    intvlVal = Ref.alloc(Ref.types.uint32),
-    intvlValLn = Ref.alloc(Ref.types.uint32, intvlVal.type.size)
+    msecVal = Ref.alloc(Ref.types.uint32),
+    msecValLn = Ref.alloc(Ref.types.uint32, msecVal.type.size)
 
   FFIBindings.getsockopt(
     fd,
     Constants.SOL_TCP,
     Constants.TCP_USER_TIMEOUT,
-    intvlVal,
-    intvlValLn
+    msecVal,
+    msecValLn
   )
 
-  return intvlVal.deref()
+  return msecVal.deref()
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,7 +217,10 @@ module.exports.getKeepAliveProbes = function getKeepAliveProbes(socket) {
 /**
  * Sets the TCP_USER_TIMEOUT value for specified socket.
  *
- * Note: The msec will be rounded towards the closest integer
+ * Notes:
+ * * This method is only supported on `linux`, will throw on `darwin` and `freebsd`.
+ * * The msec will be rounded towards the closest integer.
+ *
  *
  * @since v1.4.0
  * @param {Net.Socket} socket to set the value for
@@ -229,18 +232,20 @@ module.exports.getKeepAliveProbes = function getKeepAliveProbes(socket) {
  * NetKeepAlive.setUserTimeout(s, 30000)
  *
  * @throws {AssertionError} setUserTimeout requires two arguments
+ * @throws {AssertionError} setUserTimeout called on unsupported platform
  * @throws {AssertionError} setUserTimeout expects an instance of socket as its first argument
  * @throws {AssertionError} setUserTimeout requires msec to be a Number
  * @throws {ErrnoException|Error} Unexpected error
  */
-module.exports.setUserTimeout = function setUserTimeout(
-  socket,
-  msecs
-) {
+module.exports.setUserTimeout = function setUserTimeout(socket, msecs) {
   Assert.strictEqual(
     arguments.length,
     2,
     'setUserTimeout requires two arguments'
+  )
+  Assert(
+    Constants.TCP_USER_TIMEOUT != null,
+    'setUserTimeout called on unsupported platform'
   )
   Assert(
     _isSocket(socket),
@@ -269,6 +274,8 @@ module.exports.setUserTimeout = function setUserTimeout(
 /**
  * Returns the TCP_USER_TIMEOUT value for specified socket.
  *
+ * Note: This method is only supported on `linux`, will throw on `darwin` and `freebsd`.
+ *
  * @since v1.4.0
  * @param {Net.Socket} socket to check the value for
  *
@@ -278,6 +285,7 @@ module.exports.setUserTimeout = function setUserTimeout(
  * NetKeepAlive.getUserTimeout(s) // returns 30000 based on setter example
  *
  * @throws {AssertionError} getUserTimeout requires one arguments
+ * @throws {AssertionError} getUserTimeout called on unsupported platform
  * @throws {AssertionError} getUserTimeout expects an instance of socket as its first argument
  * @throws {ErrnoException|Error} Unexpected error
  */
@@ -286,6 +294,10 @@ module.exports.getUserTimeout = function getUserTimeout(socket) {
     arguments.length,
     1,
     'getUserTimeout requires one arguments'
+  )
+  Assert(
+    Constants.TCP_USER_TIMEOUT != null,
+    'getUserTimeout called on unsupported platform'
   )
   Assert(
     _isSocket(socket),

--- a/test/unit/test-constants.js
+++ b/test/unit/test-constants.js
@@ -57,6 +57,7 @@ describe('constants', () => {
       SOL_TCP: 6,
       TCP_KEEPINTVL: 5,
       TCP_KEEPCNT: 6,
+      TCP_USER_TIMEOUT: 18,
     })
   })
 
@@ -67,6 +68,7 @@ describe('constants', () => {
       SOL_TCP: 6,
       TCP_KEEPINTVL: 5,
       TCP_KEEPCNT: 6,
+      TCP_USER_TIMEOUT: 18,
     })
   })
 })

--- a/test/unit/test-timeout.js
+++ b/test/unit/test-timeout.js
@@ -1,0 +1,114 @@
+const Stream = require('stream')
+const Should = require('should')
+const OS = require('os')
+const Net = require('net')
+const Lib = require('../../lib')
+
+describe('TCP User Timeout', () => {
+  const itSkipOS = (skipOs, ...args) =>
+    (skipOs.includes(OS.platform()) ? it.skip : it)(...args)
+
+  it('should be a function', function () {
+    Lib.setUserTimeout.should.be.type('function')
+  })
+
+  it('should validate passed arguments', function () {
+    ;(() => Lib.setUserTimeout()).should.throw(
+      'setUserTimeout requires two arguments'
+    )
+    ;(() => Lib.setUserTimeout('')).should.throw(
+      'setUserTimeout requires two arguments'
+    )
+    ;(() => Lib.setUserTimeout('', '', '')).should.throw(
+      'setUserTimeout requires two arguments'
+    )
+    ;(() => Lib.setUserTimeout(null, 1)).should.throw(
+      'setUserTimeout expects an instance of socket as its first argument'
+    )
+    ;(() => Lib.setUserTimeout({}, 1)).should.throw(
+      'setUserTimeout expects an instance of socket as its first argument'
+    )
+    ;(() => Lib.setUserTimeout(new (class {})(), 1)).should.throw(
+      'setUserTimeout expects an instance of socket as its first argument'
+    )
+    ;(() => Lib.setUserTimeout(new Stream.PassThrough(), 1)).should.throw(
+      'setUserTimeout expects an instance of socket as its first argument'
+    )
+
+    const socket = new Net.Socket()
+    ;(() => Lib.setUserTimeout(socket, null)).should.throw(
+      'setUserTimeout requires msec to be a Number'
+    )
+    ;(() => Lib.setUserTimeout(socket, '')).should.throw(
+      'setUserTimeout requires msec to be a Number'
+    )
+    ;(() => Lib.setUserTimeout(socket, true)).should.throw(
+      'setUserTimeout requires msec to be a Number'
+    )
+    ;(() => Lib.setUserTimeout(socket, {})).should.throw(
+      'setUserTimeout requires msec to be a Number'
+    )
+  })
+
+  itSkipOS(
+    ['darwin', 'freebsd'],
+    'should throw when setsockopt returns -1',
+    (done) => {
+      const srv = Net.createServer()
+      srv.listen(0, () => {
+        const socket = Net.createConnection(srv.address(), () => {
+          ;(() => Lib.setUserTimeout(socket, -1)).should.throw(
+            /^setsockopt /i
+          )
+          socket.destroy()
+          srv.close(done)
+        })
+      })
+    }
+  )
+
+  itSkipOS(['darwin', 'freebsd'], 'should be able to set and get 4 second value', (done) => {
+    const srv = Net.createServer()
+    srv.listen(0, () => {
+      const expected = 4000
+
+      const socket = Net.createConnection(srv.address(), () => {
+        ;(() => {
+          Lib.setUserTimeout(socket, expected)
+        }).should.not.throw()
+
+        let actual
+        ;(() => {
+          actual = Lib.getUserTimeout(socket)
+        }).should.not.throw()
+
+        expected.should.eql(actual)
+
+        socket.destroy()
+        srv.close(done)
+      })
+    })
+  })
+
+  itSkipOS(['darwin', 'freebsd'], 'should throw when trying to get using invalid fd', (done) => {
+    ;(() => Lib.setUserTimeout(new Net.Socket(), 1)).should.throw(
+      'Unable to get socket fd'
+    )
+
+    const srv = Net.createServer()
+    srv.listen(0, function () {
+      const socket = Net.createConnection(this.address(), () => {
+        const oldHandle = socket._handle
+
+        socket._handle = { fd: -99999 }
+        ;(() => Lib.getUserTimeout(socket)).should.throw(
+          'getsockopt EBADF'
+        )
+
+        socket._handle = oldHandle
+        socket.destroy()
+        srv.close(done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Continuation of #103 by @mildsunrise

TODO:
- [x] fix: throw in (set|get)ters when constant value is `undefined` (all platforms except `linux`)
- [x] docs: mention supported platforms in JSDOCs
- [x] docs: mentioning the interaction between TCP_USER_TIMEOUT and TCP_KEEPALIVE and link to man page
- [ ] test: e2e tcpdump test to check if user timeout is applied
- [x] chore: reword commit messages to pass commitlint check