### PR TITLE
explicitly define the optional parameter freeResultMemory

### DIFF
--- a/lib/ffi-bindings.js
+++ b/lib/ffi-bindings.js
@@ -17,6 +17,7 @@ const createFFI = () => {
         paramsType: [cInt, cInt, cInt, cVoidRef, cInt],
         paramsValue: [fd, level, name, value, valueLength],
         errno: true,
+        freeResultMemory: false,
       })
       return [ret, errnoCode]
     },
@@ -28,6 +29,7 @@ const createFFI = () => {
         paramsType: [cInt, cInt, cInt, cVoidRef, cVoidRef],
         paramsValue: [fd, level, name, value, valueLength],
         errno: true,
+        freeResultMemory: false,
       })
       return [ret, errnoCode]
     },

--- a/lib/ffi-bindings.js
+++ b/lib/ffi-bindings.js
@@ -1,6 +1,6 @@
 const { platform } = require('os')
 const { errnoException } = require('./commons')
-const { load, DataType, open, close, arrayConstructor } = require('ffi-rs')
+const { load, DataType, open } = require('ffi-rs')
 
 const LIBRARY_NAME = 'libnative'
 
@@ -17,7 +17,6 @@ const createFFI = () => {
         paramsType: [cInt, cInt, cInt, cVoidRef, cInt],
         paramsValue: [fd, level, name, value, valueLength],
         errno: true,
-        freeResultMemory: false,
       })
       return [ret, errnoCode]
     },
@@ -29,7 +28,6 @@ const createFFI = () => {
         paramsType: [cInt, cInt, cInt, cVoidRef, cVoidRef],
         paramsValue: [fd, level, name, value, valueLength],
         errno: true,
-        freeResultMemory: false,
       })
       return [ret, errnoCode]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "ffi-rs": "1.0.83"
+        "ffi-rs": "1.0.84"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",
@@ -2196,9 +2196,9 @@
       "dev": true
     },
     "node_modules/@yuuang/ffi-rs-darwin-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.0.83.tgz",
-      "integrity": "sha512-CTqD7kbrK4hxtQtmcBFe4MOgfFpp5oZdWenZbjPaUjJcaNcqr4vyw70iM8Cm5vHRHKBlFdgLqXG7qZNptYET8w==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.0.84.tgz",
+      "integrity": "sha512-mtc0CHNei+tMPWqjRjB+U8h6DJNrsOCLC0MSU7CyDT5/N9bS1D0+hJZJXI++r9UbzC3sz9xRYu1A4gWNyV21nQ==",
       "cpu": [
         "arm64"
       ],
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-darwin-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.0.83.tgz",
-      "integrity": "sha512-nNMkiBccop0WOgGri5MWYLkszZDXcOIcyr5YxTLBoQy9fRAvrBaGOaHviftPgvEG0/J1nHvtNAFs0JtBnpP19A==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.0.84.tgz",
+      "integrity": "sha512-DdjDbcsOjF+F8MLTZR8M6jsTGkp5a5p4LBr2rGkUmjIkG4LU73LnXr7VKdXE/6WdF1YS6Bnu5Wg8cCBp3KsEfA==",
       "cpu": [
         "x64"
       ],
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-arm64-gnu": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.0.83.tgz",
-      "integrity": "sha512-NOOQuaOin7WI0sZ6u2FtqtZMbPzH9RN3TL3xbcZ0HHbt6RIMwjnZD+KpUsEizCzuYdxVI8hLTuELRaoNjwvLZg==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.0.84.tgz",
+      "integrity": "sha512-REhEBw9eTCrhFaelZc2EJsdJHWI6aXs+DxO03Gfvmok+WtAK+gPIMkYZwoYOjLb/uVFI0xfNVELgb3tMvN2DqA==",
       "cpu": [
         "arm64"
       ],
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-arm64-musl": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.0.83.tgz",
-      "integrity": "sha512-yBNznloQskt8sAiD09n6ol49nZlmeK3tTY8y/86aGnZkX4GVdQk+UwPQfe46fmwg+ndOf1XwBVwmlpzb+WmjdQ==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.0.84.tgz",
+      "integrity": "sha512-g97xLgb9tjHZ9V+MbW7CtworqhFxi77zQta/knwBW2LQIQT1VS+5SQfgZ2zhiA4pcbeKZuYSxOnoie+h16647g==",
       "cpu": [
         "arm64"
       ],
@@ -2256,9 +2256,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-x64-gnu": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.0.83.tgz",
-      "integrity": "sha512-Pqo5q0A6zNVHW0iPOHaN2G7w+I9T1lyGe2X0q5cXFzZIobuprGAhdfpUXQi3i7JomDyEWBtLfUomjpNzhDqmFA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.0.84.tgz",
+      "integrity": "sha512-9B7X3dpaIagz5l0F82xXNx2WFfqLe49A6bnj/vnaCug6NUSfHKzU4MUzY7sfvlgHCxhqbjppbaupxpQFQsnfBw==",
       "cpu": [
         "x64"
       ],
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-x64-musl": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.0.83.tgz",
-      "integrity": "sha512-JCEIMjS8AfmTC9dgfRkPgkmcgL0qCPaI1+bwduFvNaR9eMdx8hwVPb8d8mBrI6dl3TJIlj+HjovBYuBmtDTSRw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.0.84.tgz",
+      "integrity": "sha512-CcJAnQSKo85NBTVprRRamEKz3tWSR4ptFvPa/B+VSwRS/mUNisgQhTnvR9VvAIKD3n789T186nfF9FGX1x9RmA==",
       "cpu": [
         "x64"
       ],
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-arm64-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.0.83.tgz",
-      "integrity": "sha512-UqXhXhOSWGGPUa82D3m8fYiGrCFD2ATXbARyyzUu/JvoWvxlOcQ6Bb0WcD0HSj9h0Ys/vB2me8et7qBmbwQ5gA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.0.84.tgz",
+      "integrity": "sha512-CdxBmRctEJ8ZKStBUQn9TxUlyVOOHSAXihNsv/jPNoR3XMRmuFgp0MgJaSjKv+oZ52jZygakRnRIlT9Lt9sLBQ==",
       "cpu": [
         "arm64"
       ],
@@ -2301,9 +2301,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-ia32-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.0.83.tgz",
-      "integrity": "sha512-LxA8aLmJxRNAP9YFJkH5rw5xk/nIf7oLD9Z9Ns6h8Ut3CodsuXZoYIFVG3xnT2F/Pjq3v6vZ7Ud1SUFnwNwpqw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.0.84.tgz",
+      "integrity": "sha512-ka+hVS/3ReR3v5a7qwUab8EDaqHkVqHUjhzYNn9Y6AL0gfWWlbsQSnDmVFvI2NJxEkhBx3QPSzMATibhmBwiGA==",
       "cpu": [
         "x64",
         "ia32"
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-x64-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.0.83.tgz",
-      "integrity": "sha512-ylC5v/9hg7dVo5Bwv0Ujz60taWe4BSdKAy/dcRhotCO37wIPmRyP/RgLGPQPT7NGjkIoqvbnLqgBZ/cGt84fjA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.0.84.tgz",
+      "integrity": "sha512-d1rutezzI2kgurfAywNDwt0Y4qep6NjrhC31NaWYT9FHq8MHTND3TBsJEUEYhT/NCZXrnar5AuuQe+j8e8g50g==",
       "cpu": [
         "x64"
       ],
@@ -4291,19 +4291,19 @@
       }
     },
     "node_modules/ffi-rs": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.0.83.tgz",
-      "integrity": "sha512-y9g3JolHv8R7nFhZUdjfqREoWD/2K07zRRy5DkV2gSF7ljzPWH4kUIdJCHNovKbFmpAu53Ys9K+ZAAQqW3UUEw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.0.84.tgz",
+      "integrity": "sha512-WL7CI/6rOhTQZX+HvSuivToU15xmPRFyJiEWlUHd9UF5O+wQalGVl2xG66Y7MuY3PF1kr2yFe7EPoB9owMFV/w==",
       "optionalDependencies": {
-        "@yuuang/ffi-rs-darwin-arm64": "1.0.83",
-        "@yuuang/ffi-rs-darwin-x64": "1.0.83",
-        "@yuuang/ffi-rs-linux-arm64-gnu": "1.0.83",
-        "@yuuang/ffi-rs-linux-arm64-musl": "1.0.83",
-        "@yuuang/ffi-rs-linux-x64-gnu": "1.0.83",
-        "@yuuang/ffi-rs-linux-x64-musl": "1.0.83",
-        "@yuuang/ffi-rs-win32-arm64-msvc": "1.0.83",
-        "@yuuang/ffi-rs-win32-ia32-msvc": "1.0.83",
-        "@yuuang/ffi-rs-win32-x64-msvc": "1.0.83"
+        "@yuuang/ffi-rs-darwin-arm64": "1.0.84",
+        "@yuuang/ffi-rs-darwin-x64": "1.0.84",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.0.84",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.0.84",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.0.84",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.0.84",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.0.84",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.0.84",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.0.84"
       }
     },
     "node_modules/figures": {
@@ -14239,57 +14239,57 @@
       "dev": true
     },
     "@yuuang/ffi-rs-darwin-arm64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.0.83.tgz",
-      "integrity": "sha512-CTqD7kbrK4hxtQtmcBFe4MOgfFpp5oZdWenZbjPaUjJcaNcqr4vyw70iM8Cm5vHRHKBlFdgLqXG7qZNptYET8w==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.0.84.tgz",
+      "integrity": "sha512-mtc0CHNei+tMPWqjRjB+U8h6DJNrsOCLC0MSU7CyDT5/N9bS1D0+hJZJXI++r9UbzC3sz9xRYu1A4gWNyV21nQ==",
       "optional": true
     },
     "@yuuang/ffi-rs-darwin-x64": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.0.83.tgz",
-      "integrity": "sha512-nNMkiBccop0WOgGri5MWYLkszZDXcOIcyr5YxTLBoQy9fRAvrBaGOaHviftPgvEG0/J1nHvtNAFs0JtBnpP19A==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.0.84.tgz",
+      "integrity": "sha512-DdjDbcsOjF+F8MLTZR8M6jsTGkp5a5p4LBr2rGkUmjIkG4LU73LnXr7VKdXE/6WdF1YS6Bnu5Wg8cCBp3KsEfA==",
       "optional": true
     },
     "@yuuang/ffi-rs-linux-arm64-gnu": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.0.83.tgz",
-      "integrity": "sha512-NOOQuaOin7WI0sZ6u2FtqtZMbPzH9RN3TL3xbcZ0HHbt6RIMwjnZD+KpUsEizCzuYdxVI8hLTuELRaoNjwvLZg==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.0.84.tgz",
+      "integrity": "sha512-REhEBw9eTCrhFaelZc2EJsdJHWI6aXs+DxO03Gfvmok+WtAK+gPIMkYZwoYOjLb/uVFI0xfNVELgb3tMvN2DqA==",
       "optional": true
     },
     "@yuuang/ffi-rs-linux-arm64-musl": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.0.83.tgz",
-      "integrity": "sha512-yBNznloQskt8sAiD09n6ol49nZlmeK3tTY8y/86aGnZkX4GVdQk+UwPQfe46fmwg+ndOf1XwBVwmlpzb+WmjdQ==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.0.84.tgz",
+      "integrity": "sha512-g97xLgb9tjHZ9V+MbW7CtworqhFxi77zQta/knwBW2LQIQT1VS+5SQfgZ2zhiA4pcbeKZuYSxOnoie+h16647g==",
       "optional": true
     },
     "@yuuang/ffi-rs-linux-x64-gnu": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.0.83.tgz",
-      "integrity": "sha512-Pqo5q0A6zNVHW0iPOHaN2G7w+I9T1lyGe2X0q5cXFzZIobuprGAhdfpUXQi3i7JomDyEWBtLfUomjpNzhDqmFA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.0.84.tgz",
+      "integrity": "sha512-9B7X3dpaIagz5l0F82xXNx2WFfqLe49A6bnj/vnaCug6NUSfHKzU4MUzY7sfvlgHCxhqbjppbaupxpQFQsnfBw==",
       "optional": true
     },
     "@yuuang/ffi-rs-linux-x64-musl": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.0.83.tgz",
-      "integrity": "sha512-JCEIMjS8AfmTC9dgfRkPgkmcgL0qCPaI1+bwduFvNaR9eMdx8hwVPb8d8mBrI6dl3TJIlj+HjovBYuBmtDTSRw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.0.84.tgz",
+      "integrity": "sha512-CcJAnQSKo85NBTVprRRamEKz3tWSR4ptFvPa/B+VSwRS/mUNisgQhTnvR9VvAIKD3n789T186nfF9FGX1x9RmA==",
       "optional": true
     },
     "@yuuang/ffi-rs-win32-arm64-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.0.83.tgz",
-      "integrity": "sha512-UqXhXhOSWGGPUa82D3m8fYiGrCFD2ATXbARyyzUu/JvoWvxlOcQ6Bb0WcD0HSj9h0Ys/vB2me8et7qBmbwQ5gA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.0.84.tgz",
+      "integrity": "sha512-CdxBmRctEJ8ZKStBUQn9TxUlyVOOHSAXihNsv/jPNoR3XMRmuFgp0MgJaSjKv+oZ52jZygakRnRIlT9Lt9sLBQ==",
       "optional": true
     },
     "@yuuang/ffi-rs-win32-ia32-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.0.83.tgz",
-      "integrity": "sha512-LxA8aLmJxRNAP9YFJkH5rw5xk/nIf7oLD9Z9Ns6h8Ut3CodsuXZoYIFVG3xnT2F/Pjq3v6vZ7Ud1SUFnwNwpqw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.0.84.tgz",
+      "integrity": "sha512-ka+hVS/3ReR3v5a7qwUab8EDaqHkVqHUjhzYNn9Y6AL0gfWWlbsQSnDmVFvI2NJxEkhBx3QPSzMATibhmBwiGA==",
       "optional": true
     },
     "@yuuang/ffi-rs-win32-x64-msvc": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.0.83.tgz",
-      "integrity": "sha512-ylC5v/9hg7dVo5Bwv0Ujz60taWe4BSdKAy/dcRhotCO37wIPmRyP/RgLGPQPT7NGjkIoqvbnLqgBZ/cGt84fjA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.0.84.tgz",
+      "integrity": "sha512-d1rutezzI2kgurfAywNDwt0Y4qep6NjrhC31NaWYT9FHq8MHTND3TBsJEUEYhT/NCZXrnar5AuuQe+j8e8g50g==",
       "optional": true
     },
     "acorn": {
@@ -15757,19 +15757,19 @@
       }
     },
     "ffi-rs": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.0.83.tgz",
-      "integrity": "sha512-y9g3JolHv8R7nFhZUdjfqREoWD/2K07zRRy5DkV2gSF7ljzPWH4kUIdJCHNovKbFmpAu53Ys9K+ZAAQqW3UUEw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.0.84.tgz",
+      "integrity": "sha512-WL7CI/6rOhTQZX+HvSuivToU15xmPRFyJiEWlUHd9UF5O+wQalGVl2xG66Y7MuY3PF1kr2yFe7EPoB9owMFV/w==",
       "requires": {
-        "@yuuang/ffi-rs-darwin-arm64": "1.0.83",
-        "@yuuang/ffi-rs-darwin-x64": "1.0.83",
-        "@yuuang/ffi-rs-linux-arm64-gnu": "1.0.83",
-        "@yuuang/ffi-rs-linux-arm64-musl": "1.0.83",
-        "@yuuang/ffi-rs-linux-x64-gnu": "1.0.83",
-        "@yuuang/ffi-rs-linux-x64-musl": "1.0.83",
-        "@yuuang/ffi-rs-win32-arm64-msvc": "1.0.83",
-        "@yuuang/ffi-rs-win32-ia32-msvc": "1.0.83",
-        "@yuuang/ffi-rs-win32-x64-msvc": "1.0.83"
+        "@yuuang/ffi-rs-darwin-arm64": "1.0.84",
+        "@yuuang/ffi-rs-darwin-x64": "1.0.84",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.0.84",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.0.84",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.0.84",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.0.84",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.0.84",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.0.84",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.0.84"
       }
     },
     "figures": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://hertzg.github.io/node-net-keepalive/",
   "dependencies": {
-    "ffi-rs": "1.0.83"
+    "ffi-rs": "1.0.84"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",


### PR DESCRIPTION
Not sure if it belongs here, but it fixes a crash that I am experiencing on Musl systems.

The freeResultMemory should be passed to the load function. Even though it is an optional argument, I suppose it won't hurt to have it in the library code.

```
uncaught Error: Missing field `freeResultMemory`
    at Object.setsockopt (/srv/node_modules/net-keepalive/lib/ffi-bindings.js:13:41)
    at Object.setsockopt (/srv/node_modules/net-keepalive/lib/ffi-bindings.js:56:30)
    at setKeepAliveInterval (/srv/node_modules/net-keepalive/lib/index.js:85:22)
    at Socket.setKeepAliveInterval (<MY_APP>)
    at Socket.<anonymous> (<MY_APP>)
    at Object.onceWrapper (node:events:631:28)
    at Socket.emit (node:events:529:35)
    at Socket.emit (node:domain:489:12)
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1540:10)
```